### PR TITLE
Fixing support for Ruby 3.2

### DIFF
--- a/lib/happy_gemfile.rb
+++ b/lib/happy_gemfile.rb
@@ -112,7 +112,7 @@ module HappyGemfile
     end
 
     def self.gemfile
-      unless File.exists? "Gemfile"
+      unless File.exist? "Gemfile"
         puts "There doesn't appear to be a Gemfile... not sure what to do."
         return false
       end


### PR DESCRIPTION
The method .exists? have been renamed to .exist? in Ruby 3.2.